### PR TITLE
RenameSuggestion

### DIFF
--- a/src/sw/world/graph/ForceGraph.java
+++ b/src/sw/world/graph/ForceGraph.java
@@ -116,7 +116,7 @@ public class ForceGraph extends Graph {
 			return (HasForce) Vars.world.build(l2);
 		}
 
-		public HasForce other(HasForce build) {
+		public HasForce getAnotherForceLink(HasForce build) {
 			return build == l1() ? l2() : l1();
 		}
 		public boolean has(HasForce build) {
@@ -124,8 +124,8 @@ public class ForceGraph extends Graph {
 		}
 		public float ratio(HasForce from, boolean reverse) {
 			return !reverse ?
-				       from.forceConfig().beltSizeOut/other(from).forceConfig().beltSizeIn:
-				       other(from).forceConfig().beltSizeIn/from.forceConfig().beltSizeOut;
+				       from.forceConfig().beltSizeOut/ getAnotherForceLink(from).forceConfig().beltSizeIn:
+				       getAnotherForceLink(from).forceConfig().beltSizeIn/from.forceConfig().beltSizeOut;
 		}
 
 		@Override public boolean equals(Object obj) {


### PR DESCRIPTION
### Renaming Suggestion of Method Names to Make Them More Descriptive
---
**Description**
---

We have developed a tool (**NameSpotter**) for identifying non-descriptive method names, and using this tool we find a non-descriptive method name in your repository:
```java
/* Non-descriptive Method Name in src/sw/world/graph/ForceGraph.java */
		public HasForce other(HasForce build) {
			return build == l1() ? l2() : l1();
		}
```
We considered "other" as non-descriptive because it is too generic and ambiguous for readers to understand the function of the method without looking into the method body. Additionally, since there are only two forcelink objects in the class, "the other" may suit better for the context.
Consequently, we propose to rename "other" to "getTheOtherForceLink" or "getAnotherForceLink”.

Do you agree with the judgment? 

- If not, could you please leave your valuable opinion?

- If you do agree, the relevant modification has been submitted as a PR, and thanks for your precious time to consider it.